### PR TITLE
Add reusable case-study foundation

### DIFF
--- a/src/app/(case-studies)/layout.jsx
+++ b/src/app/(case-studies)/layout.jsx
@@ -1,0 +1,15 @@
+import CaseStudyBackLink from "@/components/case-studies/CaseStudyBackLink";
+import PageTransition from "@/components/PageTransition";
+import StairTransition from "@/components/StairTransition";
+
+export default function CaseStudiesLayout({ children }) {
+  return (
+    <>
+      <CaseStudyBackLink />
+      <StairTransition />
+      <PageTransition>
+        <div className="pt-16 sm:pt-20">{children}</div>
+      </PageTransition>
+    </>
+  );
+}

--- a/src/components/case-studies/CaseStudyBackLink.jsx
+++ b/src/components/case-studies/CaseStudyBackLink.jsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export default function CaseStudyBackLink() {
+  return (
+    <Button
+      asChild
+      variant="outline"
+      className="group fixed left-4 top-4 z-30 h-10 border-white/15 bg-primary/80 px-4 font-primary text-xs font-medium text-white/70 shadow-lg shadow-black/10 backdrop-blur-md hover:border-accent hover:bg-accent hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-primary sm:left-6 sm:top-6 sm:h-11 sm:px-5 sm:text-sm"
+    >
+      <Link href="/projects">
+        <ArrowLeft
+          className="mr-2 h-4 w-4 transition-transform duration-300 group-hover:-translate-x-0.5 motion-reduce:!transform-none motion-reduce:!transition-none"
+          aria-hidden="true"
+        />
+        Back to Projects
+      </Link>
+    </Button>
+  );
+}

--- a/src/components/case-studies/CaseStudyNavigation.jsx
+++ b/src/components/case-studies/CaseStudyNavigation.jsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
+import { ArrowDown, ArrowLeft, ArrowRight } from "lucide-react";
+
+function ProjectNavigationCard({ project, direction, className = "" }) {
+  const reduceMotion = useReducedMotion();
+  const isPrevious = direction === "previous";
+  const Icon = isPrevious ? ArrowLeft : ArrowRight;
+  const eyebrow = isPrevious ? "Previous project" : "Next project";
+  const iconMotion = isPrevious
+    ? "group-hover:-translate-x-1"
+    : "group-hover:translate-x-1";
+
+  return (
+    <motion.div
+      whileHover={reduceMotion ? undefined : { y: -6, scale: 1.01 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+      className={`motion-reduce:!transform-none ${className}`}
+    >
+      <Link
+        href={project.href}
+        className="group flex min-h-40 h-full items-center justify-between gap-6 rounded-[2rem] border border-white/10 bg-white/[0.025] p-7 transition-colors hover:border-accent/50 hover:bg-accent/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-primary sm:p-9"
+      >
+        {isPrevious ? (
+          <Icon
+            className={`h-6 w-6 shrink-0 text-accent transition-transform duration-300 motion-reduce:!transform-none motion-reduce:!transition-none ${iconMotion}`}
+            aria-hidden="true"
+          />
+        ) : null}
+
+        <div className={isPrevious ? "text-left" : "text-right"}>
+          <p className="text-xs uppercase tracking-[0.2em] text-white/35">
+            {eyebrow}
+          </p>
+          <p className="mt-5 text-xl font-semibold text-white transition-colors group-hover:text-accent sm:text-2xl">
+            {project.title}
+          </p>
+        </div>
+
+        {!isPrevious ? (
+          <Icon
+            className={`h-6 w-6 shrink-0 text-accent transition-transform duration-300 motion-reduce:!transform-none motion-reduce:!transition-none ${iconMotion}`}
+            aria-hidden="true"
+          />
+        ) : null}
+      </Link>
+    </motion.div>
+  );
+}
+
+function NextProjectPlaceholder({ className = "" }) {
+  return (
+    <div
+      aria-disabled="true"
+      className={`flex min-h-40 items-center rounded-[2rem] border border-white/10 bg-white/[0.025] p-7 sm:p-9 md:justify-end md:text-right ${className}`}
+    >
+      <div>
+        <p className="text-xs uppercase tracking-[0.2em] text-white/35">
+          Next case study
+        </p>
+        <p className="mt-5 text-xl font-semibold text-white/45 sm:text-2xl">
+          Coming soon
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function CaseStudyNavigation({
+  previousProject,
+  nextProject,
+  showNextPlaceholder = false,
+}) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <section className="pb-10 pt-16 sm:pb-12 sm:pt-20 lg:pb-14 lg:pt-24">
+      <div className="container mx-auto">
+        <motion.nav
+          aria-label="Case study navigation"
+          initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 24 }}
+          whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.18 }}
+          transition={{
+            duration: reduceMotion ? 0.2 : 0.5,
+            ease: "easeOut",
+          }}
+          className="motion-reduce:!transform-none"
+        >
+          <div className="grid gap-5 md:grid-cols-2">
+            {previousProject ? (
+              <ProjectNavigationCard
+                project={previousProject}
+                direction="previous"
+              />
+            ) : null}
+
+            {nextProject ? (
+              <ProjectNavigationCard
+                project={nextProject}
+                direction="next"
+                className="md:col-start-2"
+              />
+            ) : showNextPlaceholder ? (
+              <NextProjectPlaceholder className="md:col-start-2" />
+            ) : null}
+          </div>
+
+          <div className="mt-8 flex justify-center">
+            <Link
+              href="/projects"
+              className="group inline-flex items-center gap-2 rounded-sm text-xl font-semibold text-white/45 transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-4 focus-visible:ring-offset-primary sm:text-2xl"
+            >
+              <ArrowDown
+                className="h-4 w-4 transition-transform duration-300 group-hover:translate-y-1 motion-reduce:!transform-none motion-reduce:!transition-none"
+                aria-hidden="true"
+              />
+              Back to Projects
+            </Link>
+          </div>
+        </motion.nav>
+      </div>
+    </section>
+  );
+}

--- a/src/components/case-studies/CaseStudyPrimitives.jsx
+++ b/src/components/case-studies/CaseStudyPrimitives.jsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
+import { ArrowUpRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export function Reveal({ children, className = "", delay = 0, amount = 0.18 }) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 24 }}
+      whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+      viewport={{ once: true, amount }}
+      transition={{ duration: reduceMotion ? 0.2 : 0.5, delay, ease: "easeOut" }}
+      className={`motion-reduce:!transform-none ${className}`}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function SectionHeading({
+  eyebrow,
+  title,
+  description,
+  centered = false,
+  headingId,
+}) {
+  return (
+    <Reveal className={centered ? "mx-auto max-w-3xl text-center" : "max-w-3xl"}>
+      <p className="mb-4 text-xs font-semibold uppercase tracking-[0.28em] text-accent sm:text-sm">
+        {eyebrow}
+      </p>
+      <h2
+        id={headingId}
+        className="text-3xl font-semibold leading-tight text-white sm:text-4xl xl:text-5xl"
+      >
+        {title}
+      </h2>
+      {description ? (
+        <p className="mt-5 text-sm leading-7 text-white/60 sm:text-base sm:leading-8">
+          {description}
+        </p>
+      ) : null}
+    </Reveal>
+  );
+}
+
+export function TechPill({ children, reduceMotion }) {
+  return (
+    <motion.li
+      whileHover={reduceMotion ? undefined : { scale: 1.02 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+      className="rounded-full border border-white/15 bg-white/[0.04] px-4 py-2 text-xs font-medium text-white/75 backdrop-blur-sm motion-reduce:!transform-none sm:text-sm"
+    >
+      {children}
+    </motion.li>
+  );
+}
+
+export function ExternalButton({
+  href,
+  children,
+  variant = "default",
+  icon: Icon,
+}) {
+  return (
+    <Button
+      asChild
+      size="lg"
+      variant={variant}
+      className="w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-primary sm:w-auto"
+    >
+      <Link href={href} target="_blank" rel="noopener noreferrer">
+        {Icon ? <Icon className="mr-2 h-4 w-4" aria-hidden="true" /> : null}
+        {children}
+        <ArrowUpRight className="ml-2 h-4 w-4" aria-hidden="true" />
+      </Link>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

- add an immersive case-study route-group shell without the global Header
- provide a fixed accessible Back to Projects control
- add reusable reveal, heading, technology-pill, and external-CTA primitives
- add responsive previous and next project navigation with a graceful optional placeholder

## Validation

- npm run lint
- npm run build
- git diff --check
- verified the branch contains exactly four shared foundation files
- verified keyboard, focus, link, semantic navigation, and scoped reduced-motion behavior
- verified there are no individual OnePages, project assets, data changes, or Header changes

## Note

The shell deliberately reuses the existing global Stair and Page transitions. Their pre-existing reduced-motion behavior is outside this four-file foundation scope.