### PR TITLE
Improve portfolio navigation and site spacing

### DIFF
--- a/src/app/(site)/layout.jsx
+++ b/src/app/(site)/layout.jsx
@@ -7,7 +7,9 @@ export default function SiteLayout({ children }) {
     <>
       <Header />
       <StairTransition />
-      <PageTransition>{children}</PageTransition>
+      <PageTransition>
+        <div className="pb-14">{children}</div>
+      </PageTransition>
     </>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,31 +22,4 @@
   .text-outline-hover {
     -webkit-text-stroke: 1px #00ff99;
   }
-  @keyframes blink-green-white {
-    0%,
-    100% {
-      background-color: #00ff99; /* Light green */
-    }
-    50% {
-      background-color: #ffffff; /* White */
-    }
-  }
-
-  @keyframes blink-red {
-    0%,
-    100% {
-      background-color: #ff7070; /* Light red */
-    }
-    50% {
-      background-color: #ffffff; /* White */
-    }
-  }
-
-  .blink-green-white {
-    animation: blink-green-white 3.75s infinite;
-  }
-
-  .blink-red {
-    animation: blink-red 3.75s infinite;
-  }
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,41 +1,9 @@
-"use client";
-
-import { useEffect, useState } from "react";
 import { Button } from "./ui/button";
 import Nav from "./Nav";
 import MobileNav from "./MobileNav";
 import Link from "next/link";
 
-const getCurrentTimeInTimeZone = (timeZone) => {
-  const now = new Date();
-  return new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  }).format(now);
-};
-
 const Header = () => {
-  const [buttonAnimation, setButtonAnimation] = useState("");
-
-  useEffect(() => {
-    function updateButtonAnimation() {
-      const timeZone = "Europe/Athens"; // Greece timezone
-      const [hours] = getCurrentTimeInTimeZone(timeZone).split(":").map(Number);
-
-      if (hours >= 10 && hours < 20) {
-        setButtonAnimation("blink-green-white");
-      } else {
-        setButtonAnimation("blink-red");
-      }
-    }
-
-    updateButtonAnimation();
-    const intervalId = setInterval(updateButtonAnimation, 60 * 60 * 1000); // Update every hour
-    return () => clearInterval(intervalId);
-  }, []);
-
   return (
     <header className="py-8 xl:py-12 text-white">
       <div className="container mx-auto flex justify-between items-center">
@@ -46,9 +14,17 @@ const Header = () => {
         </Link>
         <div className="hidden xl:flex items-center gap-8">
           <Nav />
-          <Link href="/contact">
-            <Button className={buttonAnimation}>I'm Available!</Button>
-          </Link>
+          <div className="flex items-center gap-4 border-l border-white/10 pl-6">
+            <p className="text-sm font-medium text-white/60">
+              Open to opportunities
+            </p>
+            <Button
+              asChild
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+            >
+              <Link href="/contact">Let&rsquo;s Talk</Link>
+            </Button>
+          </div>
         </div>
         <div className="xl:hidden">
           <MobileNav />

--- a/src/components/MobileNav.jsx
+++ b/src/components/MobileNav.jsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { CiMenuFries } from "react-icons/ci";
@@ -34,31 +35,52 @@ const MobileNav = () => {
   const pathname = usePathname();
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
-      <SheetTrigger className="flex justify-center items-center">
-        <CiMenuFries className="text-[32px] text-accent" />
+      <SheetTrigger
+        aria-label="Open navigation menu"
+        className="flex justify-center items-center"
+      >
+        <CiMenuFries aria-hidden="true" className="text-[32px] text-accent" />
       </SheetTrigger>
-      <SheetContent className="flex flex-col">
-        <div className="mt-32 mb-40 text-center text-2xl">
+      <SheetContent className="flex flex-col overflow-y-auto">
+        <div className="mt-20 mb-12 text-center text-2xl">
           <Link href="/" onClick={() => setIsOpen(false)}>
             <h1 className="text-4xl font-semibold">
               Jim<span className="text-accent">.</span>
             </h1>
           </Link>
         </div>
-        <nav className="flex flex-col justify-center items-center gap-8">
-          {links.map((link, index) => {
+        <nav className="flex flex-col justify-center items-center gap-7">
+          {links.map((link) => {
+            const isActive =
+              pathname === link.path ||
+              (link.path !== "/" && pathname.startsWith(`${link.path}/`));
+
             return (
               <Link
                 href={link.path}
-                key={index}
+                key={link.path}
                 onClick={() => setIsOpen(false)}
-                className={`${link.path == pathname ? "text-accent border-b-2 border-accent" : ""} text-xl capitalize hover:text-accent transition-all`}
+                aria-current={isActive ? "page" : undefined}
+                className={`${isActive ? "text-accent border-b-2 border-accent" : ""} text-xl capitalize hover:text-accent transition-all`}
               >
                 {link.name}
               </Link>
             );
           })}
         </nav>
+        <div className="mt-10 border-t border-white/10 pt-8 text-center">
+          <p className="text-sm font-medium text-white/60">
+            Open to opportunities
+          </p>
+          <Button
+            asChild
+            className="mt-4 w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+          >
+            <Link href="/contact" onClick={() => setIsOpen(false)}>
+              Let&rsquo;s Talk
+            </Link>
+          </Button>
+        </div>
       </SheetContent>
     </Sheet>
   );

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -30,12 +30,17 @@ const Nav = () => {
   const pathname = usePathname();
   return (
     <nav className="flex gap-8">
-      {links.map((link, index) => {
+      {links.map((link) => {
+        const isActive =
+          pathname === link.path ||
+          (link.path !== "/" && pathname.startsWith(`${link.path}/`));
+
         return (
           <Link
             href={link.path}
-            key={index}
-            className={`${link.path === pathname ? "text-accent border-b-2 border-accent" : ""} capitalize font-medium hover:text-accent transition-all`}
+            key={link.path}
+            aria-current={isActive ? "page" : undefined}
+            className={`${isActive ? "text-accent border-b-2 border-accent" : ""} capitalize font-medium hover:text-accent transition-all`}
           >
             {link.name}
           </Link>


### PR DESCRIPTION
## Summary

- replace the decorative time-based availability state with an actionable Contact CTA
- provide the same recruiter-focused action inside the mobile drawer
- make desktop and mobile navigation pathname-aware and accessible
- make the mobile drawer scroll safely on short screens
- add consistent 56px bottom spacing to standard site pages
- remove obsolete availability timers and blink animations

## Validation

- npm run lint
- npm run build
- git diff --check
- verified the branch contains exactly five navigation and site-shell files
- verified the Contact CTA, active-route semantics, mobile trigger label, and drawer overflow
- verified there are no Projects, Contact implementation, case-study, asset, dependency, or instruction changes